### PR TITLE
Fix link to FuzzySecurity GitHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Vulnerabilities in Creators Update [PDF]](https://github.com/MortenSchenk/BHUSA2
 
 #### GitHub
 
-* [FuzzySecurity](github.com/FuzzySecurity)
+* [FuzzySecurity](https://github.com/FuzzySecurity)
 * [jksecurity](https://github.com/jksecurity)
 * [MortenSchenk](https://github.com/MortenSchenk)
 


### PR DESCRIPTION
It was redirecting to a non-existent folder inside this repo, because https:// protocol prefix was missing.